### PR TITLE
Corrige links de roteiros e youtube de talks like a boss

### DIFF
--- a/talk_like_a_boss/README.md
+++ b/talk_like_a_boss/README.md
@@ -7,7 +7,7 @@ atuação e contribuições na comunidade de software livre.
 ## Entrevistas
 | Entrevistadas   | Tema                                   | Link    | Roteiro | Data |
 | --------------- | -------------------------------------- | ------- | ------- | ---- |
-| Clarissa Borges e Ludimila Cruz | Trabalhando com Software Livre | [Youtube](https://youtu.be/VLYOrJexZGI)  | [Link](link.com)| 26/08/2020 |
+| Clarissa Borges e Ludimila Cruz | Trabalhando com Software Livre | [Youtube](https://youtu.be/VLYOrJexZGI)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/blob/main/talk_like_a_boss/roteiros/doc_opensource_clarissaeludi.md)| 26/08/2020 |
 | Elisa Pedrozo, Júlia Dória Miguel e Luan Larcerda | Desenvolvendo jogos na Wildlife | [Youtube](https://youtu.be/6du9815E5eM)  | [Link](link.com)| 02/09/2020 |
 | Giovanna Kobus  | Maratonas de programação | [Youtube](https://youtu.be/SmfqY9EsXUg)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/blob/main/talk_like_a_boss/roteiros/maratona_giovanna.md) | 10/09/2020 |
 | Anna | Documentação, escrita técnica e outreachy | [Youtube](https://www.youtube.com/watch?v=QgcXR94SMtA&list=PLFFHHqnY3q2FLjtGKYuI-V-z9u7jzBOb_&index=4&t=1s)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/blob/main/talk_like_a_boss/roteiros/doc_outreachy_anna.md) | 12/09/2020 |

--- a/talk_like_a_boss/README.md
+++ b/talk_like_a_boss/README.md
@@ -9,8 +9,8 @@ atuação e contribuições na comunidade de software livre.
 | --------------- | -------------------------------------- | ------- | ------- | ---- |
 | Clarissa Borges e Ludimila Cruz | Trabalhando com Software Livre | [Youtube](https://youtu.be/VLYOrJexZGI)  | [Link](link.com)| 26/08/2020 |
 | Elisa Pedrozo, Júlia Dória Miguel e Luan Larcerda | Desenvolvendo jogos na Wildlife | [Youtube](https://youtu.be/6du9815E5eM)  | [Link](link.com)| 02/09/2020 |
-| Giovanna Kobus  | Maratonas de programação | [Youtube](https://youtu.be/SmfqY9EsXUg)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/tree/master/talk_like_a_boss/roteiros/maratona_giovana.md) | 10/09/2020 |
-| Anna | Documentação, escrita técnica e outreachy | [Youtube](https://youtu.be/lNiINslvmrg)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/tree/master/talk_like_a_boss/doc_outreachy_anna.md) | 12/09/2020 |
+| Giovanna Kobus  | Maratonas de programação | [Youtube](https://youtu.be/SmfqY9EsXUg)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/blob/main/talk_like_a_boss/roteiros/maratona_giovanna.md) | 10/09/2020 |
+| Anna | Documentação, escrita técnica e outreachy | [Youtube](https://www.youtube.com/watch?v=QgcXR94SMtA&list=PLFFHHqnY3q2FLjtGKYuI-V-z9u7jzBOb_&index=4&t=1s)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/blob/main/talk_like_a_boss/roteiros/doc_outreachy_anna.md) | 12/09/2020 |
 | Camilla Maciel e Renata Soares | Desafios da carreira na área de Tecnologia, mentorias e liderança | [Youtube](https://www.youtube.com/watch?v=YQMH11KXDCA&feature=youtu.be)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/blob/main/talk_like_a_boss/roteiros/doc_carreira_renataecamila.md) | 23/09/2020 |
 
 ## Sugestões

--- a/talk_like_a_boss/README.md
+++ b/talk_like_a_boss/README.md
@@ -8,7 +8,7 @@ atuação e contribuições na comunidade de software livre.
 | Entrevistadas   | Tema                                   | Link    | Roteiro | Data |
 | --------------- | -------------------------------------- | ------- | ------- | ---- |
 | Clarissa Borges e Ludimila Cruz | Trabalhando com Software Livre | [Youtube](https://youtu.be/VLYOrJexZGI)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/blob/main/talk_like_a_boss/roteiros/doc_opensource_clarissaeludi.md)| 26/08/2020 |
-| Elisa Pedrozo, Júlia Dória Miguel e Luan Larcerda | Desenvolvendo jogos na Wildlife | [Youtube](https://youtu.be/6du9815E5eM)  | [Link](link.com)| 02/09/2020 |
+| Elisa Pedrozo, Júlia Dória Miguel e Luan Larcerda | Desenvolvendo jogos na Wildlife | [Youtube](https://youtu.be/6du9815E5eM)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/blob/main/talk_like_a_boss/roteiros/doc_wildlife.md)| 02/09/2020 |
 | Giovanna Kobus  | Maratonas de programação | [Youtube](https://youtu.be/SmfqY9EsXUg)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/blob/main/talk_like_a_boss/roteiros/maratona_giovanna.md) | 10/09/2020 |
 | Anna | Documentação, escrita técnica e outreachy | [Youtube](https://www.youtube.com/watch?v=QgcXR94SMtA&list=PLFFHHqnY3q2FLjtGKYuI-V-z9u7jzBOb_&index=4&t=1s)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/blob/main/talk_like_a_boss/roteiros/doc_outreachy_anna.md) | 12/09/2020 |
 | Camilla Maciel e Renata Soares | Desafios da carreira na área de Tecnologia, mentorias e liderança | [Youtube](https://www.youtube.com/watch?v=YQMH11KXDCA&feature=youtu.be)  | [Link](https://github.com/BOSS-BigOpenSourceSister/BigSister/blob/main/talk_like_a_boss/roteiros/doc_carreira_renataecamila.md) | 23/09/2020 |

--- a/talk_like_a_boss/roteiros/doc_opensource_clarissaeludi.md
+++ b/talk_like_a_boss/roteiros/doc_opensource_clarissaeludi.md
@@ -1,0 +1,49 @@
+# Entrevistas
+Esse roteiro é específico para entrevista. Fiquem a vontade para customizar as perguntas. Sugerimos que, com antecedência, ele seja lido em conjunto e conversado com todas as participantes (entrevistadoras e entrevistadas). Lembrem-se de sempre dar espaço para todos as envolvidas falarem; um jeito de fazer isso é definindo previamente quem fala o quê.
+
+> Seria interessante falar tudo com o gênero feminino, pois somos uma comunidade que todas as protagonistas são mulheres, além disso estamos falando para outras mulheres da comunidade ou que estão conhecendo e querendo fazer parte.
+
+## Introdução - X min
+**[Entrevistadora 1]** Cumprimentar quem tá assistindo;
+
+## Auto apresentação:
+**[Entrevistadora 1]** “Sou Entrevistada 1 e sou tal coisa” 
+
+**[Entrevistadora 2]** “e eu sou a Entrevistada 2 e sou tal coisa”
+
+**[Entrevistadora 1]** Apresentar o tema: Trabalhando com Open source
+
+Apresentar as entrevistadas:
+“Hoje vamos falar com a:”
+
+- Ludimila Bela cruz
+- Desenvolvedora iOS no Picpay, ex-líder técnica na Secretaria Municipal de Educação de São Paulo, onde atuou com foco em iniciativas de transparência usando software livre, em especial o Pátio Digital. Engenheira de software pela UnB, desenvolvedora mobile, web e entusiasta devops, membro do comitê de seleção de sotware livre cultural pelo LabLivre de 2018 a 2019. Monitora no Afropython e Django girls, mentora no Reprograma e em iniciativas internas do Picpay para ensinar mulheres a programar. Nas horas vagas falo e escrevo sobre diversidade, vejo friends e brinco com a dog aqui de casa.
+**[Entrevistadora 2]**
+- Clarissa Borges
+- Estudante de Engenharia de Software na UnB. Entusiasta de FOSS e membro da Fundação GNOME, iniciou suas contribuições através do Outreachy em 2018 e continuou no projeto GNOME e na comunidade brasileira desde então.  Pelas suas contribuições e preocupação com os usuários do GNOME, foi a primeira ganhadora do prêmio Outstanding New Free Software Contributor, promovido pela Free Software Foundation. Atualmente participando de um projeto no GNOME pelo GSoC e buscando meios de atrair novos e diversos tipos de contribuidores para o projeto GNOME.
+
+**[Entrevistadora 1]**
+O que não tem no seu linkedin e você quer contar pra gente?
+**[Entrevistadora 2]**
+Conte um pouco mais sobre a trajetória até trabalhar com software livre.
+
+
+**[Entrevistadora 1]**
+Como ganha dinheiro com open source se o código é aberto?
+**[Entrevistadora 2]**
+O que você mais gosta/gostava quando tava trabalhando com software livre?
+Dicas e sugestões - X min
+
+**[Entrevistadora 1]**
+É preciso saber inglês para trabalhar com open source?
+**[Entrevistadora 2]**
+Como costuma se envolver com as comunidades?
+Entrevistadoras já fala que estão acabando e deixa elas darem as últimas mensagens 
+
+**[Entrevistadora 1]**
+Agradece a audiência
+Curte, compartilha blablablablabla
+**[Entrevistadora 2]**
+Se tiver data da próxima entrevista (A cada 15 dias), informar, ou avisar para ficar atenta às redes sociais do BOSS que trará informações de novas entrevistas.
+
+

--- a/talk_like_a_boss/roteiros/doc_wildlife.md
+++ b/talk_like_a_boss/roteiros/doc_wildlife.md
@@ -1,0 +1,36 @@
+__Esse roteiro é específico para entrevista. Fiquem a vontade para customizar as perguntas. Sugerimos que, com antecedência, ele seja lido em conjunto e conversado com todas as participantes (entrevistadoras e entrevistadas). Lembrem-se de sempre dar espaço para todos as envolvidas falarem; um jeito de fazer isso é definindo previamente quem fala o quê.__
+
+>Seria interessante falar tudo com o gênero feminino, pois somos uma comunidade que todas as protagonistas são mulheres, além disso estamos falando para outras mulheres da comunidade ou que estão conhecendo e querendo fazer parte.
+
+# Introdução - 5min
+**[Entrevistadora 1]**Cumprimentar quem tá assistindo e apresenta convidadas;
+
+
+- Elisa Pedrozo
+
+- Desenvolvedora de software apaixonada por ciência, entusiasta de novas tecnologias e em resolver desafios.Formada em ciência da computação pela UFMG , experiência na universidade de londres (goldsmiths) https://github.com/elisapsp
+- I'm a software developer in love about science, that showed that the right amount of passion, hard work, and creativity can bring all sorts of impossible things to life.
+- Work at Wildlife, one of the leading mobile game developers and publishers in the world, building successful products and providing fun to millions of people every day. I'm enthusiastic about new technologies and solving challenging problems.
+
+- Júlia Dória Miguel 
+
+- Trabalha na wildlife como coordenadora de comunicação e Marca. Formada em administração/business Universidade do Estado de Santa Catarina,  
+
+- Luan Guimarães
+- Faz parte da equipe de SRE, Site Reliability Engineering. Formado pela FGA, Universidade de Brasília
+
+- Brand & Comms Coordinator at Wildlife Studios
+
+
+
+**[Entrevistadora 2]** O que não tem no seu linkedin e você quer contar pra gente?
+Conte um pouco mais sobre a trajetória até trabalhar com jogos
+Se vc pudesse dar um conselho para você na época de faculdade, qual seria?
+Durante o trabalho - X min
+
+	
+**[Entrevistadora 1]**
+Agradece a audiência
+Curte, compartilha blablablablabla
+**[Entrevistadora 2]**
+Se tiver data da próxima entrevista (A cada 15 dias), informar, ou avisar para ficar atenta às redes sociais do BOSS que trará informações de novas entrevistas.


### PR DESCRIPTION
## Descrição

Resolve issue #94 . Corrige alguns links do README da Talk Like a BOSS que estão quebrados.

## Tarefas gerais realizadas
- [x] Trabalhando com Software Livre (Roteiro)
- [x] Desenvolvendo jogos na Wildlife (Roteiro)
- [x] Maratonas de programação (Roteiro)
- [x] Documentação, escrita técnica e outreachy (Roteiro e Youtube)
